### PR TITLE
[feature] implement check_file.rb

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,8 @@ Metrics/BlockLength:
     # Vagrantfile is not application code, rather, configuration file and
     # blocks in it tends to be long
     - "**/Vagrantfile"
+    # gemspec tends to have long block
+    - "**/*.gemspec"
   ExcludedMethods:
     # these two exclude long blocks in `_spec.rb`
     - describe

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,5 @@ language: ruby
 rvm:
   - 2.3.1
 before_install: gem install bundler -v 1.14.6
+script:
+  - bundle exec rake ci

--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source "https://rubygems.org"
 
-# Specify your gem's dependencies in sensu-plugins-example.gemspec
+# Specify your gem's dependencies in sensu-plugin-example.gemspec
 gemspec

--- a/Guardfile
+++ b/Guardfile
@@ -1,0 +1,11 @@
+guard :rspec, cmd: "rspec" do
+  watch(%r{^spec/.+_spec\.rb$})
+  watch(%r{^lib/(.+)\.rb$})     { |m| "spec/#{m[1]}_spec.rb" }
+  watch("spec/spec_helper.rb")  { "spec" }
+end
+
+guard :rubocop do
+  watch(/.+\.rb$/)
+  watch(%r{(?:.+/)?\.rubocop(?:_todo)?\.yml$}) { |m| File.dirname(m[0]) }
+end
+# vim: ft=ruby

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# `sensu-plugins-example`
+# `sensu-plugin-example`
 
 This is an example `sensu` plug-in for demonstration.
 

--- a/Rakefile
+++ b/Rakefile
@@ -12,3 +12,6 @@ end
 
 desc "Run tests"
 task test: [:spec, :rubocop]
+
+desc "Run tests and build"
+task ci: [:test, :build]

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "sensu/plugins/example"
+require "sensu/plugin/example"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/exe/check_file.rb
+++ b/exe/check_file.rb
@@ -1,0 +1,11 @@
+#!/usr/bin/env ruby
+
+require "sensu/plugin/example/check_file"
+
+# Usage:
+#
+# check_file.rb filename
+class CheckFile < Sensu::Plugin::Example::CheckFile
+  # set a short name, instead of `Sensu::Plugin::Example::CheckFile`
+  Sensu::Plugin::Example::CheckFile.check_name(self)
+end

--- a/lib/sensu/plugin/example.rb
+++ b/lib/sensu/plugin/example.rb
@@ -1,7 +1,8 @@
-require "sensu/plugins/example/version"
+require "sensu/plugin/example/version"
+require "sensu/plugin/example/check_file"
 
 module Sensu
-  module Plugins
+  module Plugin
     # This is an example sensu-plugin for demonstration. It is not intened to
     # be used in production environment.
     module Example

--- a/lib/sensu/plugin/example/check_file.rb
+++ b/lib/sensu/plugin/example/check_file.rb
@@ -1,0 +1,46 @@
+require "sensu-plugin/check/cli"
+require "pathname"
+
+module Sensu
+  module Plugin
+    module Example
+      # a simple check to test if the given file exist
+      class CheckFile < Sensu::Plugin::Check::CLI
+        option :debug,
+               short: "-d",
+               default: false
+
+        option :version,
+               long: "--version",
+               default: false
+
+        def run
+          show_version_and_exit if config[:version]
+          $stderr.puts "DEBUG: debug enabled" if config[:debug]
+          if exist?
+            ok "File #{file} exists"
+          else
+            critical "File #{file} does not exist"
+          end
+        end
+
+        def file
+          Pathname.new(argv.first)
+        end
+
+        def version
+          Sensu::Plugin::Example::VERSION
+        end
+
+        def exist?
+          File.exist?(file)
+        end
+
+        def show_version_and_exit
+          $stdout.puts version
+          exit 0
+        end
+      end
+    end
+  end
+end

--- a/lib/sensu/plugin/example/version.rb
+++ b/lib/sensu/plugin/example/version.rb
@@ -1,5 +1,5 @@
 module Sensu
-  module Plugins
+  module Plugin
     module Example
       VERSION = "0.1.0".freeze
     end

--- a/sensu-plugin-example.gemspec
+++ b/sensu-plugin-example.gemspec
@@ -1,4 +1,5 @@
 # coding: utf-8
+
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 require "sensu/plugin/example/version"

--- a/sensu-plugin-example.gemspec
+++ b/sensu-plugin-example.gemspec
@@ -1,11 +1,11 @@
 # coding: utf-8
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require "sensu/plugins/example/version"
+require "sensu/plugin/example/version"
 
 Gem::Specification.new do |spec|
-  spec.name          = "sensu-plugins-example"
-  spec.version       = Sensu::Plugins::Example::VERSION
+  spec.name          = "sensu-plugin-example"
+  spec.version       = Sensu::Plugin::Example::VERSION
   spec.authors       = ["Tomoyuki Sakurai"]
   spec.email         = ["tomoyukis@reallyenglish.com"]
 
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   # rubocop:disable Metrics/LineLength
   spec.description   = "This plug-in is an example sensu-plugin for demonstration"
   # rubocop:enable Metrics/LineLength
-  spec.homepage      = "http://example.org/"
+  spec.homepage      = "https://github.com/reallyenglish/sensu-plugin-example"
 
   # Prevent pushing this gem to RubyGems.org. To allow pushes either set the
   # 'allowed_push_host' to allow pushing to a single host or delete this
@@ -32,8 +32,12 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_runtime_dependency "sensu-plugin", "~> 2.1.0"
+
   spec.add_development_dependency "bundler", "~> 1.14"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "rubocop", "~> 0.47.1"
+  spec.add_development_dependency "guard-rspec", "~> 4.7.3"
+  spec.add_development_dependency "guard-rubocop", "~> 1.3.0"
 end

--- a/spec/sensu/plugin/example/check_file_spec.rb
+++ b/spec/sensu/plugin/example/check_file_spec.rb
@@ -1,0 +1,33 @@
+require "spec_helper"
+require_relative "../../../../lib/sensu/plugin/example/check_file"
+
+RSpec.describe Sensu::Plugin::Example::CheckFile do
+  let(:file) { "/etc/hosts" }
+  let(:pathname) { Pathname.new(file) }
+  let(:check) { Sensu::Plugin::Example::CheckFile.new([file]) }
+
+  describe "#new" do
+    it "does not raise error" do
+      expect { check }.not_to raise_error
+    end
+  end
+
+  describe ".file" do
+    it "returns file name" do
+      expect(check.file).to eq pathname
+    end
+  end
+
+  describe ".version" do
+    it "returns version" do
+      expect(check.version).to eq Sensu::Plugin::Example::VERSION
+    end
+  end
+
+  describe ".exist?" do
+    it "tests the given file with File.exist?" do
+      expect(File).to receive(:exist?).with(pathname)
+      check.exist?
+    end
+  end
+end

--- a/spec/sensu/plugin/example_spec.rb
+++ b/spec/sensu/plugin/example_spec.rb
@@ -1,8 +1,8 @@
 require "spec_helper"
 
-RSpec.describe Sensu::Plugins::Example do
+RSpec.describe Sensu::Plugin::Example do
   it "has a version number" do
-    expect(Sensu::Plugins::Example::VERSION).not_to be nil
+    expect(Sensu::Plugin::Example::VERSION).not_to be nil
   end
 
   it "does something useful" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,16 @@
 require "bundler/setup"
-require "sensu/plugins/example"
+require "sensu/plugin/example"
+
+module Sensu
+  module Plugin
+    class CLI
+      # rubocop:disable Style/ClassVars:
+      # disable autorun at_exit during tests
+      @@autorun = false
+      # rubocop:enable Style/ClassVars:
+    end
+  end
+end
 
 RSpec.configure do |config|
   # Enable flags like --only-failures and --next-failure


### PR DESCRIPTION
this check is a very simple `sensu` plug-in as an example for reference. the PR includes spec, `Guardfile` and CI target.

bad news is, i failed to give the repository a proper name in line with the standard naming scheme, which means the repository must be destroyed and re-created. after merging the PR, i will create `sensu-plugin-example`. all commit history must be deleted as the commit logs include references to PRs.